### PR TITLE
Add pyproject packaging and license for ark-realsense

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Sarthak Das
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/intel_realsense/__init__.py
+++ b/intel_realsense/__init__.py
@@ -1,0 +1,6 @@
+"""Intel RealSense camera package for the Ark robotics framework."""
+
+from .intel_realsense import IntelRealSense, Drivers
+from .intel_realsense_driver import IntelRealSenseDriver
+
+__all__ = ["IntelRealSense", "Drivers", "IntelRealSenseDriver"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ark-realsense"
+version = "0.1.0"
+description = "Intel RealSense sensor integration for the Ark robotics stack"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {file = "LICENSE"}
+authors = [{name = "Sarthak Das", email = "sdas4@icloud.com"}]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+    "pyrealsense2",
+    "numpy",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.package-data]
+intel_realsense = ["*.yaml"]


### PR DESCRIPTION
## Summary
- add pyproject.toml defining project metadata and build configuration
- include MIT license and package initializer for intel_realsense

## Testing
- `pip install -e . --no-deps` *(fails: Could not find a version that satisfies the requirement setuptools>=69)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a49d2573a0832190ca1efb45c88723